### PR TITLE
Avoid 'reference to reference' error with strict C++03 compiler.

### DIFF
--- a/include/boost/iterator/is_lvalue_iterator.hpp
+++ b/include/boost/iterator/is_lvalue_iterator.hpp
@@ -9,6 +9,7 @@
 #include <boost/detail/workaround.hpp>
 #include <boost/detail/iterator.hpp>
 
+#include <boost/type_traits/add_lvalue_reference.hpp>
 #include <boost/iterator/detail/any_conversion_eater.hpp>
 
 // should be the last #includes
@@ -52,7 +53,7 @@ namespace detail
       // convertible to Value const&
       struct conversion_eater
       {
-          conversion_eater(Value&);
+          conversion_eater(typename add_lvalue_reference<Value>::type);
       };
 
       static char tester(conversion_eater, int);

--- a/include/boost/iterator/is_readable_iterator.hpp
+++ b/include/boost/iterator/is_readable_iterator.hpp
@@ -6,6 +6,7 @@
 
 #include <boost/mpl/bool.hpp>
 #include <boost/detail/iterator.hpp>
+#include <boost/type_traits/add_lvalue_reference.hpp>
 
 #include <boost/type_traits/detail/bool_trait_def.hpp>
 #include <boost/iterator/detail/any_conversion_eater.hpp>
@@ -26,7 +27,7 @@ namespace detail
   template <class Value>
   struct is_readable_iterator_impl
   {
-      static char tester(Value&, int);
+      static char tester(typename add_lvalue_reference<Value>::type, int);
       static char (& tester(any_conversion_eater, ...) )[2];
 
       template <class It>

--- a/include/boost/iterator/iterator_facade.hpp
+++ b/include/boost/iterator/iterator_facade.hpp
@@ -22,6 +22,7 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/add_const.hpp>
 #include <boost/type_traits/add_pointer.hpp>
+#include <boost/type_traits/add_lvalue_reference.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/is_convertible.hpp>
@@ -284,7 +285,15 @@ namespace iterators {
       : mpl::eval_if<
             mpl::and_<
                 // A proxy is only needed for readable iterators
-                is_convertible<Reference,Value const&>
+                is_convertible<
+                    Reference
+                    // Use add_lvalue_reference to form `reference to Value` due to
+                    // some (strict) C++03 compilers (e.g. `gcc -std=c++03`) reject
+                    // 'reference-to-reference' in the template which described in CWG
+                    // DR106.
+                    // http://www.open-std.org/Jtc1/sc22/wg21/docs/cwg_defects.html#106
+                  , typename add_lvalue_reference<Value const>::type
+                >
 
                 // No multipass iterator can have values that disappear
                 // before positions can be re-visited


### PR DESCRIPTION
This change will fix Range's tests; [DebSidC++ - range - join / gcc-4.9.1~98](http://www.boost.org/development/tests/develop/developer/output/DebSidC++-boost-bin-v2-libs-range-test-join-test-gcc-4-9-1~98-debug-link-static-threading-multi.html).

Tested under, x86-64 linux with
- GCC 4.8.3(gnu++03,c++03,gnu++11,c++11,gnu++1y,c++1y)
- Clang 3.4(gnu++03,c++03,gnu++11,c++11,gnu++1y,c++1y).

Also, it might fix similar error on older msvc (I didn't test, because I have no such msvc...).
- [VC8 jc-bell - range - join / msvc-8.0](http://www.boost.org/development/tests/develop/developer/output/VC8%20jc-bell-boost-bin-v2-libs-range-test-join-test-msvc-8-0-debug-link-static-threading-multi.html)
- [teeks99-08a-win2012R2-64on64 - range - join / msvc-8.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-08a-win2012R2-64on64-boost-bin-v2-libs-range-test-join-test-msvc-8-0-debug-link-static-threading-multi.html)
- [teeks99-08b-win2012R2-64on64 - range - join / msvc-9.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-08b-win2012R2-64on64-boost-bin-v2-libs-range-test-join-test-msvc-9-0-debug-link-static-threading-multi.html)
- [teeks99-test - range - join / msvc-8.0](http://www.boost.org/development/tests/develop/developer/output/teeks99-test-boost-bin-v2-libs-range-test-join-test-msvc-8-0-debug-address-model-64-link-static-threading-multi.html)
