### PR TITLE
Remove unused pure_traversal_tag import into boost::iterators::detail

### DIFF
--- a/include/boost/iterator/iterator_categories.hpp
+++ b/include/boost/iterator/iterator_categories.hpp
@@ -168,13 +168,6 @@ struct pure_traversal_tag
 {
 };
 
-// This import is needed for backward compatibility with Boost.Range:
-// boost/range/detail/demote_iterator_traversal_tag.hpp
-// It should be removed when that header is fixed.
-namespace detail {
-using iterators::pure_traversal_tag;
-} // namespace detail
-
 //
 // Trait to retrieve one of the iterator traversal tags from the iterator category or traversal.
 //


### PR DESCRIPTION
As Boost.Range has been updated, there is no need to import pure_traversal_tag into boost::iterators::detail.