### PR TITLE
Fixed type-clash with tag "use_default" from other boost-libs.

### DIFF
--- a/include/boost/iterator/detail/facade_iterator_category.hpp
+++ b/include/boost/iterator/detail/facade_iterator_category.hpp
@@ -31,11 +31,11 @@
 //
 
 namespace boost {
-namespace iterators {
 
 // forward declaration
 struct use_default;
 
+namespace iterators {
 namespace detail {
 
 struct input_output_iterator_tag

--- a/include/boost/iterator/iterator_adaptor.hpp
+++ b/include/boost/iterator/iterator_adaptor.hpp
@@ -32,16 +32,11 @@
 #include <boost/iterator/iterator_traits.hpp>
 
 namespace boost {
-namespace iterators {
 
-  // Used as a default template argument internally, merely to
-  // indicate "use the default", this can also be passed by users
-  // explicitly in order to specify that the default should be used.
-  struct use_default;
-
-} // namespace iterators
-
-using iterators::use_default;
+// Used as a default template argument internally, merely to
+// indicate "use the default", this can also be passed by users
+// explicitly in order to specify that the default should be used.
+struct use_default;
 
 // the incompleteness of use_default causes massive problems for
 // is_convertible (naturally).  This workaround is fortunately not


### PR DESCRIPTION
Moved declaration of `use_default` into namespace `boost` instead of declaring it in namespace `boost::iterator` and pulling it into namespace `boost` afterwards via `using`-directive.

The clash with the original code would occur for the following simple code, for example:
```
#include <boost/type_erasure/iterator.hpp>
#include <boost/iterator/iterator_adaptor.hpp>
```
Both, GCC and Clang fail to compile this, but Clang is more verbose:

    /tmp/boost-1_58/boost/iterator/iterator_adaptor.hpp:44:18: error: target of using declaration conflicts with declaration already in scope
    using iterators::use_default;
                     ^
    /tmp/boost-1_58/boost/iterator/iterator_adaptor.hpp:40:10: note: target of using declaration
      struct use_default;
             ^
    /tmp/boost-1_58/boost/type_erasure/iterator.hpp:27:8: note: conflicting declaration
    struct use_default;
           ^
    1 error generated.
