### PR TITLE
Remove deprecated includes

### DIFF
--- a/include/boost/iterator/filter_iterator.hpp
+++ b/include/boost/iterator/filter_iterator.hpp
@@ -7,7 +7,6 @@
 #ifndef BOOST_FILTER_ITERATOR_23022003THW_HPP
 #define BOOST_FILTER_ITERATOR_23022003THW_HPP
 
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 

--- a/include/boost/iterator/indirect_iterator.hpp
+++ b/include/boost/iterator/indirect_iterator.hpp
@@ -7,12 +7,10 @@
 #ifndef BOOST_INDIRECT_ITERATOR_23022003THW_HPP
 #define BOOST_INDIRECT_ITERATOR_23022003THW_HPP
 
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 
 #include <boost/pointee.hpp>
 #include <boost/indirect_reference.hpp>
-#include <boost/detail/iterator.hpp>
 
 #include <boost/detail/indirect_traits.hpp>
 
@@ -24,6 +22,8 @@
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/not.hpp>
 #include <boost/mpl/has_xxx.hpp>
+
+#include <iterator>
 
 #ifdef BOOST_MPL_CFG_NO_HAS_XXX
 # include <boost/shared_ptr.hpp>
@@ -45,7 +45,7 @@ namespace iterators {
     template <class Iter, class Value, class Category, class Reference, class Difference>
     struct indirect_base
     {
-        typedef typename boost::detail::iterator_traits<Iter>::value_type dereferenceable;
+        typedef typename std::iterator_traits<Iter>::value_type dereferenceable;
 
         typedef iterator_adaptor<
             indirect_iterator<Iter, Value, Category, Reference, Difference>

--- a/include/boost/iterator/is_lvalue_iterator.hpp
+++ b/include/boost/iterator/is_lvalue_iterator.hpp
@@ -4,15 +4,14 @@
 #ifndef IS_LVALUE_ITERATOR_DWA2003112_HPP
 # define IS_LVALUE_ITERATOR_DWA2003112_HPP
 
-#include <boost/iterator.hpp>
-
 #include <boost/detail/workaround.hpp>
-#include <boost/detail/iterator.hpp>
 
 #include <boost/type_traits/add_lvalue_reference.hpp>
 #include <boost/iterator/detail/any_conversion_eater.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/aux_/lambda_support.hpp>
+
+#include <iterator>
 
 // should be the last #includes
 #include <boost/type_traits/integral_constant.hpp>
@@ -125,14 +124,14 @@ namespace detail
   template <class It>
   struct is_readable_lvalue_iterator_impl
     : is_lvalue_iterator_impl<
-          BOOST_DEDUCED_TYPENAME boost::detail::iterator_traits<It>::value_type const
+          BOOST_DEDUCED_TYPENAME std::iterator_traits<It>::value_type const
       >::template rebind<It>
   {};
 
   template <class It>
   struct is_non_const_lvalue_iterator_impl
     : is_lvalue_iterator_impl<
-          BOOST_DEDUCED_TYPENAME boost::detail::iterator_traits<It>::value_type
+          BOOST_DEDUCED_TYPENAME std::iterator_traits<It>::value_type
       >::template rebind<It>
   {};
 } // namespace detail

--- a/include/boost/iterator/is_readable_iterator.hpp
+++ b/include/boost/iterator/is_readable_iterator.hpp
@@ -6,10 +6,11 @@
 
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/aux_/lambda_support.hpp>
-#include <boost/detail/iterator.hpp>
 #include <boost/type_traits/add_lvalue_reference.hpp>
 
 #include <boost/iterator/detail/any_conversion_eater.hpp>
+
+#include <iterator>
 
 // should be the last #include
 #include <boost/type_traits/integral_constant.hpp>
@@ -93,7 +94,7 @@ namespace detail
   template <class It>
   struct is_readable_iterator_impl2
     : is_readable_iterator_impl<
-          BOOST_DEDUCED_TYPENAME boost::detail::iterator_traits<It>::value_type const
+          BOOST_DEDUCED_TYPENAME std::iterator_traits<It>::value_type const
       >::template rebind<It>
   {};
 } // namespace detail

--- a/include/boost/iterator/iterator_adaptor.hpp
+++ b/include/boost/iterator/iterator_adaptor.hpp
@@ -8,8 +8,6 @@
 #define BOOST_ITERATOR_ADAPTOR_23022003THW_HPP
 
 #include <boost/static_assert.hpp>
-#include <boost/iterator.hpp>
-#include <boost/detail/iterator.hpp>
 
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/iterator/iterator_facade.hpp>

--- a/include/boost/iterator/iterator_archetypes.hpp
+++ b/include/boost/iterator/iterator_archetypes.hpp
@@ -9,7 +9,6 @@
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/operators.hpp>
 #include <boost/static_assert.hpp>
-#include <boost/iterator.hpp>
 
 #include <boost/iterator/detail/facade_iterator_category.hpp>
 

--- a/include/boost/iterator/iterator_categories.hpp
+++ b/include/boost/iterator/iterator_categories.hpp
@@ -7,7 +7,6 @@
 # define BOOST_ITERATOR_CATEGORIES_HPP
 
 # include <boost/config.hpp>
-# include <boost/detail/iterator.hpp>
 # include <boost/iterator/detail/config_def.hpp>
 
 # include <boost/detail/workaround.hpp>
@@ -20,6 +19,8 @@
 # include <boost/type_traits/is_convertible.hpp>
 
 # include <boost/static_assert.hpp>
+
+#include <iterator>
 
 namespace boost {
 namespace iterators {
@@ -116,7 +117,7 @@ struct iterator_category_to_traversal
 template <class Iterator = mpl::_1>
 struct iterator_traversal
   : iterator_category_to_traversal<
-        typename boost::detail::iterator_traits<Iterator>::iterator_category
+        typename std::iterator_traits<Iterator>::iterator_category
     >
 {};
 

--- a/include/boost/iterator/iterator_concepts.hpp
+++ b/include/boost/iterator/iterator_concepts.hpp
@@ -9,9 +9,6 @@
 #include <boost/concept_check.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 
-// Use boost::detail::iterator_traits to work around some MSVC/Dinkumware problems.
-#include <boost/detail/iterator.hpp>
-
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/is_integral.hpp>
 
@@ -27,6 +24,7 @@
 #include <boost/config.hpp>
 
 #include <algorithm>
+#include <iterator>
 
 #include <boost/concept/detail/concept_def.hpp>
 
@@ -44,8 +42,8 @@ namespace boost_concepts
     , boost::CopyConstructible<Iterator>
 
   {
-      typedef BOOST_DEDUCED_TYPENAME boost::detail::iterator_traits<Iterator>::value_type value_type;
-      typedef BOOST_DEDUCED_TYPENAME boost::detail::iterator_traits<Iterator>::reference reference;
+      typedef BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::value_type value_type;
+      typedef BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::reference reference;
 
       BOOST_CONCEPT_USAGE(ReadableIterator)
       {
@@ -59,7 +57,7 @@ namespace boost_concepts
 
   template <
       typename Iterator
-    , typename ValueType = BOOST_DEDUCED_TYPENAME boost::detail::iterator_traits<Iterator>::value_type
+    , typename ValueType = BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::value_type
   >
   struct WritableIterator
     : boost::CopyConstructible<Iterator>
@@ -75,7 +73,7 @@ namespace boost_concepts
 
   template <
       typename Iterator
-    , typename ValueType = BOOST_DEDUCED_TYPENAME boost::detail::iterator_traits<Iterator>::value_type
+    , typename ValueType = BOOST_DEDUCED_TYPENAME std::iterator_traits<Iterator>::value_type
   >
   struct WritableIteratorConcept : WritableIterator<Iterator,ValueType> {};
 
@@ -92,7 +90,7 @@ namespace boost_concepts
 
   BOOST_concept(LvalueIterator,(Iterator))
   {
-      typedef typename boost::detail::iterator_traits<Iterator>::value_type value_type;
+      typedef typename std::iterator_traits<Iterator>::value_type value_type;
 
       BOOST_CONCEPT_USAGE(LvalueIterator)
       {
@@ -144,7 +142,7 @@ namespace boost_concepts
     : SinglePassIterator<Iterator>
     , boost::DefaultConstructible<Iterator>
   {
-      typedef typename boost::detail::iterator_traits<Iterator>::difference_type difference_type;
+      typedef typename std::iterator_traits<Iterator>::difference_type difference_type;
 
       BOOST_MPL_ASSERT((boost::is_integral<difference_type>));
       BOOST_MPL_ASSERT_RELATION(std::numeric_limits<difference_type>::is_signed, ==, true);
@@ -221,7 +219,7 @@ namespace boost_concepts
         boost::random_access_traversal_tag, boost::random_access_traversal_tag)
     {
         bool b;
-        typename boost::detail::iterator_traits<Iterator2>::difference_type n;
+        typename std::iterator_traits<Iterator2>::difference_type n;
         b = i1 <  i2;
         b = i1 <= i2;
         b = i1 >  i2;

--- a/include/boost/iterator/iterator_facade.hpp
+++ b/include/boost/iterator/iterator_facade.hpp
@@ -8,7 +8,6 @@
 #define BOOST_ITERATOR_FACADE_23022003THW_HPP
 
 #include <boost/config.hpp>
-#include <boost/iterator.hpp>
 #include <boost/iterator/interoperable.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/iterator/iterator_categories.hpp>
@@ -36,6 +35,8 @@
 #include <boost/mpl/always.hpp>
 #include <boost/mpl/apply.hpp>
 #include <boost/mpl/identity.hpp>
+
+#include <cstddef>
 
 #include <boost/iterator/detail/config_def.hpp> // this goes last
 

--- a/include/boost/iterator/iterator_traits.hpp
+++ b/include/boost/iterator/iterator_traits.hpp
@@ -5,8 +5,9 @@
 #ifndef ITERATOR_TRAITS_DWA200347_HPP
 # define ITERATOR_TRAITS_DWA200347_HPP
 
-# include <boost/detail/iterator.hpp>
 # include <boost/detail/workaround.hpp>
+
+#include <iterator>
 
 namespace boost {
 namespace iterators {
@@ -19,32 +20,32 @@ namespace iterators {
 template <class Iterator>
 struct iterator_value
 {
-    typedef typename boost::detail::iterator_traits<Iterator>::value_type type;
+    typedef typename std::iterator_traits<Iterator>::value_type type;
 };
 
 template <class Iterator>
 struct iterator_reference
 {
-    typedef typename boost::detail::iterator_traits<Iterator>::reference type;
+    typedef typename std::iterator_traits<Iterator>::reference type;
 };
 
 
 template <class Iterator>
 struct iterator_pointer
 {
-    typedef typename boost::detail::iterator_traits<Iterator>::pointer type;
+    typedef typename std::iterator_traits<Iterator>::pointer type;
 };
 
 template <class Iterator>
 struct iterator_difference
 {
-    typedef typename boost::detail::iterator_traits<Iterator>::difference_type type;
+    typedef typename std::iterator_traits<Iterator>::difference_type type;
 };
 
 template <class Iterator>
 struct iterator_category
 {
-    typedef typename boost::detail::iterator_traits<Iterator>::iterator_category type;
+    typedef typename std::iterator_traits<Iterator>::iterator_category type;
 };
 
 } // namespace iterators

--- a/include/boost/iterator/new_iterator_tests.hpp
+++ b/include/boost/iterator/new_iterator_tests.hpp
@@ -32,7 +32,6 @@
 # include <boost/type_traits.hpp>
 # include <boost/static_assert.hpp>
 # include <boost/concept_archetype.hpp> // for detail::dummy_constructor
-# include <boost/detail/iterator.hpp>
 # include <boost/pending/iterator_tests.hpp>
 # include <boost/iterator/is_readable_iterator.hpp>
 # include <boost/iterator/is_lvalue_iterator.hpp>
@@ -76,7 +75,7 @@ template <class Iterator, class T>
 void readable_iterator_test(const Iterator i1, T v)
 {
   Iterator i2(i1); // Copy Constructible
-  typedef typename detail::iterator_traits<Iterator>::reference ref_t;
+  typedef typename std::iterator_traits<Iterator>::reference ref_t;
   ref_t r1 = *i1;
   ref_t r2 = *i2;
   T v1 = r1;
@@ -112,9 +111,9 @@ template <class Iterator>
 void swappable_iterator_test(Iterator i, Iterator j)
 {
   Iterator i2(i), j2(j);
-  typename detail::iterator_traits<Iterator>::value_type bi = *i, bj = *j;
+  typename std::iterator_traits<Iterator>::value_type bi = *i, bj = *j;
   iter_swap(i2, j2);
-  typename detail::iterator_traits<Iterator>::value_type ai = *i, aj = *j;
+  typename std::iterator_traits<Iterator>::value_type ai = *i, aj = *j;
   BOOST_TEST(bi == aj && bj == ai);
 }
 
@@ -122,8 +121,8 @@ template <class Iterator, class T>
 void constant_lvalue_iterator_test(Iterator i, T v1)
 {
   Iterator i2(i);
-  typedef typename detail::iterator_traits<Iterator>::value_type value_type;
-  typedef typename detail::iterator_traits<Iterator>::reference reference;
+  typedef typename std::iterator_traits<Iterator>::value_type value_type;
+  typedef typename std::iterator_traits<Iterator>::reference reference;
   BOOST_STATIC_ASSERT((is_same<const value_type&, reference>::value));
   const T& v2 = *i2;
   BOOST_TEST(v1 == v2);
@@ -137,8 +136,8 @@ template <class Iterator, class T>
 void non_const_lvalue_iterator_test(Iterator i, T v1, T v2)
 {
   Iterator i2(i);
-  typedef typename detail::iterator_traits<Iterator>::value_type value_type;
-  typedef typename detail::iterator_traits<Iterator>::reference reference;
+  typedef typename std::iterator_traits<Iterator>::value_type value_type;
+  typedef typename std::iterator_traits<Iterator>::reference reference;
   BOOST_STATIC_ASSERT((is_same<value_type&, reference>::value));
   T& v3 = *i2;
   BOOST_TEST(v1 == v3);
@@ -229,7 +228,7 @@ void random_access_readable_iterator_test(Iterator i, int N, TrueVals vals)
   {
     BOOST_TEST(i == j + c);
     BOOST_TEST(*i == vals[c]);
-    typename detail::iterator_traits<Iterator>::value_type x = j[c];
+    typename std::iterator_traits<Iterator>::value_type x = j[c];
     BOOST_TEST(*i == x);
     BOOST_TEST(*i == *(j + c));
     BOOST_TEST(*i == *(c + j));
@@ -245,7 +244,7 @@ void random_access_readable_iterator_test(Iterator i, int N, TrueVals vals)
   {
     BOOST_TEST(i == k - c);
     BOOST_TEST(*i == vals[N - 1 - c]);
-    typename detail::iterator_traits<Iterator>::value_type x = j[N - 1 - c];
+    typename std::iterator_traits<Iterator>::value_type x = j[N - 1 - c];
     BOOST_TEST(*i == x);
     Iterator q = k - c; 
     BOOST_TEST(*i == *q);

--- a/include/boost/iterator/permutation_iterator.hpp
+++ b/include/boost/iterator/permutation_iterator.hpp
@@ -21,13 +21,13 @@ template< class ElementIterator
 class permutation_iterator
   : public iterator_adaptor<
              permutation_iterator<ElementIterator, IndexIterator>
-           , IndexIterator, typename boost::detail::iterator_traits<ElementIterator>::value_type
-           , use_default, typename boost::detail::iterator_traits<ElementIterator>::reference>
+           , IndexIterator, typename std::iterator_traits<ElementIterator>::value_type
+           , use_default, typename std::iterator_traits<ElementIterator>::reference>
 {
   typedef iterator_adaptor<
             permutation_iterator<ElementIterator, IndexIterator>
-          , IndexIterator, typename boost::detail::iterator_traits<ElementIterator>::value_type
-          , use_default, typename boost::detail::iterator_traits<ElementIterator>::reference> super_t;
+          , IndexIterator, typename std::iterator_traits<ElementIterator>::value_type
+          , use_default, typename std::iterator_traits<ElementIterator>::reference> super_t;
 
   friend class iterator_core_access;
 

--- a/include/boost/iterator/reverse_iterator.hpp
+++ b/include/boost/iterator/reverse_iterator.hpp
@@ -8,7 +8,6 @@
 #define BOOST_REVERSE_ITERATOR_23022003THW_HPP
 
 #include <boost/next_prior.hpp>
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 
 namespace boost {

--- a/include/boost/iterator/transform_iterator.hpp
+++ b/include/boost/iterator/transform_iterator.hpp
@@ -7,7 +7,6 @@
 #ifndef BOOST_TRANSFORM_ITERATOR_23022003THW_HPP
 #define BOOST_TRANSFORM_ITERATOR_23022003THW_HPP
 
-#include <boost/iterator.hpp>
 #include <boost/iterator/detail/enable_if.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/iterator_categories.hpp>
@@ -22,11 +21,12 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/result_of.hpp>
 
+#include <iterator>
 
 #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
 # include <boost/type_traits/is_base_and_derived.hpp>
-
 #endif
+
 #include <boost/iterator/detail/config_def.hpp>
 
 

--- a/include/boost/iterator/zip_iterator.hpp
+++ b/include/boost/iterator/zip_iterator.hpp
@@ -9,7 +9,6 @@
 # define BOOST_ZIP_ITERATOR_TMB_07_13_2003_HPP_
 
 #include <stddef.h>
-#include <boost/iterator.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/iterator_adaptor.hpp> // for enable_if_convertible

--- a/include/boost/pending/detail/int_iterator.hpp
+++ b/include/boost/pending/detail/int_iterator.hpp
@@ -6,11 +6,12 @@
 #ifndef BOOST_INT_ITERATOR_H
 #define BOOST_INT_ITERATOR_H
 
-#include <boost/iterator.hpp>
 #if !defined BOOST_MSVC
 #include <boost/operators.hpp>
 #endif
 #include <iostream>
+#include <iterator>
+#include <cstddef>
 //using namespace std;
 
 #ifndef BOOST_NO_OPERATORS_IN_NAMESPACE

--- a/include/boost/pending/iterator_tests.hpp
+++ b/include/boost/pending/iterator_tests.hpp
@@ -215,7 +215,7 @@ void random_access_iterator_test(Iterator i, int N, TrueVals vals)
   const Iterator j = i;
   int c;
 
-  typedef typename boost::detail::iterator_traits<Iterator>::value_type value_type;
+  typedef typename std::iterator_traits<Iterator>::value_type value_type;
 
   for (c = 0; c < N-1; ++c) {
     assert(i == j + c);

--- a/include/boost/pointee.hpp
+++ b/include/boost/pointee.hpp
@@ -20,6 +20,8 @@
 # include <boost/mpl/if.hpp>
 # include <boost/mpl/eval_if.hpp>
 
+#include <iterator>
+
 namespace boost {
 
 namespace detail
@@ -33,7 +35,7 @@ namespace detail
   template <class Iterator>
   struct iterator_pointee
   {
-      typedef typename iterator_traits<Iterator>::value_type value_type;
+      typedef typename std::iterator_traits<Iterator>::value_type value_type;
 
       struct impl
       {


### PR DESCRIPTION
A comment in boost/iterator.hpp and boost/detail/iterator.hpp mentions that
the files are obsolete and will be deprecated. All they do is pull some types
from namespace std into namespace boost.

Same as #16, this time with all files pushed to the github repo.