### PR TITLE
Fix test compilation

### DIFF
--- a/test/concept_tests.cpp
+++ b/test/concept_tests.cpp
@@ -7,13 +7,16 @@
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/operators.hpp>
 
+#include <iterator>
+#include <cstddef>
+
 struct new_random_access
   : std::random_access_iterator_tag
   , boost::random_access_traversal_tag
 {};
 
 struct new_iterator
-  : public boost::iterator< new_random_access, int >
+  : public std::iterator< new_random_access, int >
 {
   int& operator*() const { return *m_x; }
   new_iterator& operator++() { return *this; }
@@ -33,7 +36,7 @@ struct new_iterator
 new_iterator operator+(std::ptrdiff_t, new_iterator x) { return x; }
 
 struct old_iterator
-  : public boost::iterator<std::random_access_iterator_tag, int>
+  : public std::iterator<std::random_access_iterator_tag, int>
 {
   int& operator*() const { return *m_x; }
   old_iterator& operator++() { return *this; }

--- a/test/indirect_iterator_test.cpp
+++ b/test/indirect_iterator_test.cpp
@@ -32,6 +32,7 @@
 #include <vector>
 #include <stdlib.h>
 #include <set>
+#include <iterator>
 
 #if !defined(__SGI_STL_PORT)                            \
     && (defined(BOOST_MSVC_STD_ITERATOR)                \
@@ -164,7 +165,7 @@ main()
 
     BOOST_STATIC_ASSERT(
         has_element_type<
-            boost::detail::iterator_traits<shared_t::iterator>::value_type
+            std::iterator_traits<shared_t::iterator>::value_type
         >::value
         );
     


### PR DESCRIPTION
boost/iterator.hpp was implicitly dragged in via boost/operators.hpp, from which it was removed in https://github.com/boostorg/utility/commit/cb6500161b682a66438604e75ab901c46e42430d. It's not needed anyway, all it does is map boost::iterator to std::iterator.