### PR TITLE
Support lambda expressions in function_input_iterator

### DIFF
--- a/include/boost/iterator/function_input_iterator.hpp
+++ b/include/boost/iterator/function_input_iterator.hpp
@@ -17,6 +17,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/none.hpp>
 #include <boost/optional/optional.hpp>
+#include <boost/utility/result_of.hpp>
 
 namespace boost {
 
@@ -28,9 +29,9 @@ namespace iterators {
         class function_input_iterator
             : public iterator_facade<
             function_input_iterator<Function, Input>,
-            typename Function::result_type,
+            BOOST_DEDUCED_TYPENAME result_of<Function ()>::type,
             single_pass_traversal_tag,
-            typename Function::result_type const &
+            BOOST_DEDUCED_TYPENAME result_of<Function ()>::type const &
             >
         {
         public:
@@ -46,7 +47,7 @@ namespace iterators {
                 ++state;
             }
 
-            typename Function::result_type const &
+            BOOST_DEDUCED_TYPENAME result_of<Function ()>::type const &
                 dereference() const {
                     return (value ? value : value = (*f)()).get();
             }
@@ -58,7 +59,7 @@ namespace iterators {
         private:
             Function * f;
             Input state;
-            mutable optional<typename Function::result_type> value;
+            mutable optional<BOOST_DEDUCED_TYPENAME result_of<Function ()>::type> value;
         };
 
         template <class Function, class Input>

--- a/test/function_input_iterator_test.cpp
+++ b/test/function_input_iterator_test.cpp
@@ -96,6 +96,23 @@ int main(int argc, char * argv[])
         assert(generated[i] == 42 + i);
     cout << "function iterator test with stateful function object successful." << endl;
 
+#if !defined(BOOST_NO_CXX11_LAMBDAS) && !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS)
+    // test the iterator with lambda expressions
+    int num = 42;
+    auto lambda_generator = [&num] { return num++; };
+    vector<int>().swap(generated);
+    copy(
+        boost::make_function_input_iterator(lambda_generator, 0),
+        boost::make_function_input_iterator(lambda_generator, 10),
+        back_inserter(generated)
+        );
+
+    assert(generated.size() == 10);
+    for(std::size_t i = 0; i != 10; ++i)
+        assert(generated[i] == 42 + i);
+    cout << "function iterator test with lambda expressions successful." << endl;
+#endif // BOOST_NO_CXX11_LAMBDAS
+
     return 0;
 }
 


### PR DESCRIPTION
I want to use lamda expressions in `function_input_iterator`.

Tested under windows 10 64bit with
- g++ 4.8.1 (`-std=c++03`, `-std=c++11`, `-std=c++1y`, `-std=gnu++03`, `-std=gnu++11`, `-std=gnu++1y`)
- clang++ 3.7.0 (`-std=c++03`, `-std=c++11`, `-std=c++14`, `-std=c++1z`, `-std=gnu++98`, `-std=gnu++11`, `-std=gnu++14`, `-std=gnu++1z`)
- msvc 12.0, 14.0
