### PR TITLE
Bug fix for ticket #12895: Apply remove_reference before remove_cv

### DIFF
--- a/include/boost/iterator/zip_iterator.hpp
+++ b/include/boost/iterator/zip_iterator.hpp
@@ -83,7 +83,7 @@ namespace iterators {
       struct result<This(Iterator)>
       {
         typedef typename
-          remove_reference<typename remove_cv<Iterator>::type>::type
+          remove_cv<typename remove_reference<Iterator>::type>::type
         iterator;
 
         typedef typename iterator_reference<iterator>::type type;


### PR DESCRIPTION
The suggested code change ensures that the zip_iterator dereference also works for Standard Libraries where iterator_traits are not SFINAE-friendly (e.g. Visual Studio 2012)