### PR TITLE
Testcase for PR #22 (trac ticket 12895)

### DIFF
--- a/test/detail/zip_iterator_test.ipp
+++ b/test/detail/zip_iterator_test.ipp
@@ -59,6 +59,18 @@ int main()
     }
 
     {
+        // Trac #12895
+        boost::zip_iterator<
+            TUPLE<int*, std::string*>
+        > i(MAKE_TUPLE(vi.data(), vs.data()));
+
+        BOOST_TEST(boost::fusion::at_c<0>(* i     ) == 42);
+        BOOST_TEST(boost::fusion::at_c<1>(* i     ) == "kokoro");
+        BOOST_TEST(boost::fusion::at_c<0>(*(i + 1)) == 72);
+        BOOST_TEST(boost::fusion::at_c<1>(*(i + 1)) == "pyonpyon");
+    }
+
+    {
         boost::zip_iterator<iterator_tuple> i1(MAKE_TUPLE(vi.begin(), vs.begin()));
         boost::zip_iterator<iterator_tuple> i2(MAKE_TUPLE(vi.end(),   vs.end()));
 


### PR DESCRIPTION
Before applying PR #22: this testcase fails to compile.
After: it runs successfully.
(Note that it fails to compile only if the TR1-style `boost::result_of` is used — i.e. compiled in a C++03 mode or `BOOST_RESULT_OF_USE_TR1` is defined.)

Adapted from Daniel's testcase in trac ticket 12895.