### PR TITLE
Remove dependency on boost::prior.

### DIFF
--- a/include/boost/iterator/reverse_iterator.hpp
+++ b/include/boost/iterator/reverse_iterator.hpp
@@ -7,7 +7,6 @@
 #ifndef BOOST_REVERSE_ITERATOR_23022003THW_HPP
 #define BOOST_REVERSE_ITERATOR_23022003THW_HPP
 
-#include <boost/next_prior.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 
 namespace boost {
@@ -39,7 +38,12 @@ namespace iterators {
       {}
 
    private:
-      typename super_t::reference dereference() const { return *boost::prior(this->base()); }
+      typename super_t::reference dereference() const
+      {
+          Iterator it = this->base_reference();
+          --it;
+          return *it;
+      }
 
       void increment() { --this->base_reference(); }
       void decrement() { ++this->base_reference(); }


### PR DESCRIPTION
This allows to use `boost::reverse_iterator` in `next_prior.hpp`. It also weakens the dependency on Boost.Utility, although not removes it.
