### PR TITLE
Clean up function_input_iterator

### DIFF
--- a/include/boost/iterator/function_input_iterator.hpp
+++ b/include/boost/iterator/function_input_iterator.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
+#include <boost/core/addressof.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/function_types/is_function_pointer.hpp>
 #include <boost/function_types/is_function_reference.hpp>
@@ -38,7 +39,7 @@ namespace iterators {
         public:
             function_input_iterator() {}
             function_input_iterator(Function & f_, Input state_ = Input())
-                : f(&f_), state(state_) {}
+                : f(boost::addressof(f_)), state(state_) {}
 
             void increment() {
                 if(value)

--- a/include/boost/iterator/function_input_iterator.hpp
+++ b/include/boost/iterator/function_input_iterator.hpp
@@ -31,9 +31,9 @@ namespace iterators {
         class function_input_iterator
             : public iterator_facade<
             function_input_iterator<Function, Input>,
-            BOOST_DEDUCED_TYPENAME result_of<Function ()>::type,
+            typename result_of<Function ()>::type,
             single_pass_traversal_tag,
-            BOOST_DEDUCED_TYPENAME result_of<Function ()>::type const &
+            typename result_of<Function ()>::type const &
             >
         {
         public:
@@ -49,7 +49,7 @@ namespace iterators {
                 ++state;
             }
 
-            BOOST_DEDUCED_TYPENAME result_of<Function ()>::type const &
+            typename result_of<Function ()>::type const &
                 dereference() const {
                     return (value ? value : value = (*f)()).get();
             }
@@ -61,7 +61,7 @@ namespace iterators {
         private:
             Function * f;
             Input state;
-            mutable optional<BOOST_DEDUCED_TYPENAME result_of<Function ()>::type> value;
+            mutable optional<typename result_of<Function ()>::type> value;
         };
 
         template <class Function, class Input>

--- a/include/boost/iterator/function_input_iterator.hpp
+++ b/include/boost/iterator/function_input_iterator.hpp
@@ -14,7 +14,6 @@
 #include <boost/core/addressof.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/function_types/is_function_pointer.hpp>
-#include <boost/function_types/is_function_reference.hpp>
 #include <boost/function_types/result_type.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/none.hpp>
@@ -101,16 +100,6 @@ namespace iterators {
             mutable optional<typename function_types::result_type<Function>::type> value;
         };
 
-        template <class Function, class Input>
-        class function_reference_input_iterator
-            : public function_pointer_input_iterator<Function*,Input>
-        {
-        public:
-            function_reference_input_iterator(Function & f_, Input state_ = Input())
-                : function_pointer_input_iterator<Function*,Input>(&f_, state_)
-            {}
-        };
-
     } // namespace impl
 
     template <class Function, class Input>
@@ -118,21 +107,13 @@ namespace iterators {
         : public mpl::if_<
             function_types::is_function_pointer<Function>,
             impl::function_pointer_input_iterator<Function,Input>,
-            typename mpl::if_<
-                function_types::is_function_reference<Function>,
-                impl::function_reference_input_iterator<Function,Input>,
-                impl::function_input_iterator<Function,Input>
-            >::type
+            impl::function_input_iterator<Function,Input>
         >::type
     {
         typedef typename mpl::if_<
             function_types::is_function_pointer<Function>,
             impl::function_pointer_input_iterator<Function,Input>,
-            typename mpl::if_<
-                function_types::is_function_reference<Function>,
-                impl::function_reference_input_iterator<Function,Input>,
-                impl::function_input_iterator<Function,Input>
-            >::type
+            impl::function_input_iterator<Function,Input>
         >::type base_type;
     public:
         function_input_iterator(Function & f, Input i)

--- a/test/function_input_iterator_test.cpp
+++ b/test/function_input_iterator_test.cpp
@@ -6,7 +6,6 @@
 #include <cstddef>
 
 #include <algorithm>
-#include <iostream>
 #include <iterator>
 #include <vector>
 


### PR DESCRIPTION
This PR makes a few small-scale clean ups
- Use `boost::addressof` instead of `&`.
- Remove unnecessary headers in test.
- Replace `BOOST_DEDUCED_TYPENAME` with `typename`. (`function_input_iterator.hpp` includes headers that do not support ancient compilers. So it doesn't make sense to continue to use `BOOST_DEDUCED_TYPENAME`.)

and one moderate-scale clean up
- Remove dead class template (`function_reference_input_iterator`).

I have a plan to make another larger-size clean up:
integrate `function_pointer_input_iterator` into `function_input_iterator`. These two classes have many duplicate codes, which is bad for maintenance.