### PR TITLE
Fix lambda test

### DIFF
--- a/test/function_input_iterator_test.cpp
+++ b/test/function_input_iterator_test.cpp
@@ -90,7 +90,8 @@ int main()
     for(std::size_t i = 0; i != 10; ++i)
         BOOST_TEST_EQ(generated[i], static_cast<int>(42 + i));
 
-#if !defined(BOOST_NO_CXX11_LAMBDAS) && !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS)
+#if !defined(BOOST_NO_CXX11_LAMBDAS) && !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) \
+ && !defined(BOOST_NO_CXX11_DECLTYPE_N3276)
     // test the iterator with lambda expressions
     int num = 42;
     auto lambda_generator = [&num] { return num++; };

--- a/test/function_input_iterator_test.cpp
+++ b/test/function_input_iterator_test.cpp
@@ -85,7 +85,7 @@ int main()
         back_inserter(generated)
         );
 
-    BOOST_TEST_EQ(generated.size(), 10);
+    BOOST_TEST_EQ(generated.size(), 10u);
     BOOST_TEST_EQ(counter_generator.n, 42 + 10);
     for(std::size_t i = 0; i != 10; ++i)
         BOOST_TEST_EQ(generated[i], static_cast<int>(42 + i));


### PR DESCRIPTION
The lambda test fails on some compilers. This PR disables the test on compilers that do not have enough features.
- TR1-style decltype does not support C++11 lambdas. They need decltype-based result_of (which is used when `BOOST_NO_CXX11_DECLTYPE_N3276` is not defined) to deduce the type.

Drive by fix: suppress signed-unsigned comparison warning.