### PR TITLE
Fix usage of decltype-based result_of in transform_iterator.

### DIFF
--- a/include/boost/iterator/transform_iterator.hpp
+++ b/include/boost/iterator/transform_iterator.hpp
@@ -47,7 +47,11 @@ namespace iterators {
         // the function.
         typedef typename ia_dflt_help<
             Reference
+#ifdef BOOST_RESULT_OF_USE_TR1
           , result_of<const UnaryFunc(typename std::iterator_traits<Iterator>::reference)>
+#else
+          , result_of<const UnaryFunc&(typename std::iterator_traits<Iterator>::reference)>
+#endif
         >::type reference;
 
         // To get the default for Value: remove any reference on the


### PR DESCRIPTION
Regardless of value categories of a `transform_iterator` object, its dereference operator calls `m_f` as an lvalue. Thus, correct usage of `result_of` in C++11 is `result_of<const UnaryFunc&(...)>`.