### PR TITLE
fix uninitialized variable in default constructor of generator_iterator

### DIFF
--- a/include/boost/generator_iterator.hpp
+++ b/include/boost/generator_iterator.hpp
@@ -36,7 +36,7 @@ class generator_iterator
     > super_t;
 
  public:
-    generator_iterator() {}
+    generator_iterator() : m_g(0) {}
     generator_iterator(Generator* g) : m_g(g), m_value((*m_g)()) {}
 
     void increment()


### PR DESCRIPTION
This is an improvement that was sitting in Boost.Uuid seed_rng.hpp which I would like to move into the implementation proper.  By initializing the generator pointer, it ensures that "end" iterators are never valid nor do they match other iterators.