### PR TITLE
Inheriting std::iterator is deprecated in c++17.

### DIFF
--- a/include/boost/iterator/iterator_archetypes.hpp
+++ b/include/boost/iterator/iterator_archetypes.hpp
@@ -426,15 +426,16 @@ namespace detail
       >::type iterator_category;
 
       // Needed for some broken libraries (see below)
-      typedef boost::iterator<
-          iterator_category
-        , Value
-        , typename traversal_archetype_base<
+      struct workaround_iterator_base
+      {
+        typedef typename iterator_archetype_base::iterator_category iterator_category;
+        typedef Value value_type;
+        typedef typename traversal_archetype_base<
               Value, AccessCategory, TraversalCategory
-          >::difference_type
-        , typename access::pointer
-        , typename access::reference
-      > workaround_iterator_base;
+          >::difference_type difference_type;
+        typedef typename access::pointer pointer;
+        typedef typename access::reference reference;
+      };
   };
 }
 

--- a/test/concept_tests.cpp
+++ b/test/concept_tests.cpp
@@ -16,8 +16,13 @@ struct new_random_access
 {};
 
 struct new_iterator
-  : public std::iterator< new_random_access, int >
 {
+  typedef new_random_access iterator_category;
+  typedef int value_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef int* pointer;
+  typedef int& reference;
+
   int& operator*() const { return *m_x; }
   new_iterator& operator++() { return *this; }
   new_iterator operator++(int) { return *this; }
@@ -36,8 +41,13 @@ struct new_iterator
 new_iterator operator+(std::ptrdiff_t, new_iterator x) { return x; }
 
 struct old_iterator
-  : public std::iterator<std::random_access_iterator_tag, int>
 {
+  typedef std::random_access_iterator_tag iterator_category;
+  typedef int value_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef int* pointer;
+  typedef int& reference;
+
   int& operator*() const { return *m_x; }
   old_iterator& operator++() { return *this; }
   old_iterator operator++(int) { return *this; }

--- a/test/is_lvalue_iterator.cpp
+++ b/test/is_lvalue_iterator.cpp
@@ -5,10 +5,10 @@
 #include <deque>
 #include <iterator>
 #include <iostream>
+#include <cstddef> // std::ptrdiff_t
 #include <boost/static_assert.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/iterator/is_lvalue_iterator.hpp>
-#include <boost/iterator.hpp>
 
 // Last, for BOOST_NO_LVALUE_RETURN_DETECTION
 #include <boost/iterator/detail/config_def.hpp>
@@ -20,29 +20,36 @@ struct v
 };
 
 
-struct value_iterator : boost::iterator<std::input_iterator_tag,v>
+struct value_iterator
 {
+    typedef std::input_iterator_tag iterator_category;
+    typedef v value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef v* pointer;
+    typedef v& reference;
+
     v operator*() const;
 };
 
-struct noncopyable_iterator : boost::iterator<std::forward_iterator_tag,boost::noncopyable>
+struct noncopyable_iterator
 {
+    typedef std::forward_iterator_tag iterator_category;
+    typedef boost::noncopyable value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef boost::noncopyable* pointer;
+    typedef boost::noncopyable& reference;
+	
     boost::noncopyable const& operator*() const;
 };
 
 template <class T>
 struct proxy_iterator
-  : boost::iterator<std::output_iterator_tag,T>
 {
     typedef T value_type;
-    
-#if BOOST_WORKAROUND(__GNUC__, == 2)
-    typedef boost::iterator<std::input_iterator_tag,value_type> base;
-    typedef base::iterator_category iterator_category;
-    typedef base::difference_type difference_type;
-    typedef base::pointer pointer;
-    typedef base::reference reference;
-#endif 
+    typedef std::output_iterator_tag iterator_category;
+    typedef std::ptrdiff_t difference_type;
+    typedef T* pointer;
+    typedef T& reference;
     
     struct proxy
     {

--- a/test/is_readable_iterator.cpp
+++ b/test/is_readable_iterator.cpp
@@ -5,10 +5,10 @@
 #include <deque>
 #include <iterator>
 #include <iostream>
+#include <cstddef> // std::ptrdiff_t
 #include <boost/static_assert.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/iterator/is_readable_iterator.hpp>
-#include <boost/iterator.hpp>
 
 // Last, for BOOST_NO_LVALUE_RETURN_DETECTION
 #include <boost/iterator/detail/config_def.hpp>
@@ -20,26 +20,35 @@ struct v
 };
 
 
-struct value_iterator : boost::iterator<std::input_iterator_tag,v>
+struct value_iterator
 {
+    typedef std::input_iterator_tag iterator_category;
+    typedef v value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef v* pointer;
+    typedef v& reference;
+
     v operator*() const;
 };
 
-struct noncopyable_iterator : boost::iterator<std::forward_iterator_tag,boost::noncopyable>
+struct noncopyable_iterator
 {
+    typedef std::forward_iterator_tag iterator_category;
+    typedef boost::noncopyable value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef boost::noncopyable* pointer;
+    typedef boost::noncopyable& reference;
+	
     boost::noncopyable const& operator*() const;
 };
 
-struct proxy_iterator : boost::iterator<std::output_iterator_tag,v>
+struct proxy_iterator
 {
-#if BOOST_WORKAROUND(__GNUC__, == 2)
-    typedef boost::iterator<std::input_iterator_tag,v> base;
-    typedef base::iterator_category iterator_category;
-    typedef base::value_type value_type;
-    typedef base::difference_type difference_type;
-    typedef base::pointer pointer;
-    typedef base::reference reference;
-#endif 
+    typedef std::output_iterator_tag iterator_category;
+    typedef v value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef v* pointer;
+    typedef v& reference;
     
     struct proxy
     {
@@ -50,16 +59,13 @@ struct proxy_iterator : boost::iterator<std::output_iterator_tag,v>
     proxy operator*() const;
 };
 
-struct proxy_iterator2 : boost::iterator<std::output_iterator_tag,v>
+struct proxy_iterator2
 {
-#if BOOST_WORKAROUND(__GNUC__, == 2)
-    typedef boost::iterator<std::input_iterator_tag,v> base;
-    typedef base::iterator_category iterator_category;
-    typedef base::value_type value_type;
-    typedef base::difference_type difference_type;
-    typedef base::pointer pointer;
-    typedef base::reference reference;
-#endif 
+    typedef std::output_iterator_tag iterator_category;
+    typedef v value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef v* pointer;
+    typedef v& reference;
     
     struct proxy
     {


### PR DESCRIPTION
Boost's iterator.hpp is deprecated, too. Therefore get rid of all of that and replace inheritance by lifting std::iterator's members into the derived class.

Signed-off-by: Daniela Engert <dani@ngrt.de>