### PR TITLE
Use use_default from Boost.Core

### DIFF
--- a/include/boost/iterator/detail/facade_iterator_category.hpp
+++ b/include/boost/iterator/detail/facade_iterator_category.hpp
@@ -4,6 +4,8 @@
 #ifndef FACADE_ITERATOR_CATEGORY_DWA20031118_HPP
 # define FACADE_ITERATOR_CATEGORY_DWA20031118_HPP
 
+# include <boost/core/use_default.hpp>
+
 # include <boost/iterator/iterator_categories.hpp>
 
 # include <boost/mpl/or.hpp>  // used in iterator_tag inheritance logic
@@ -33,8 +35,7 @@
 namespace boost {
 namespace iterators {
 
-// forward declaration
-struct use_default;
+using boost::use_default;
 
 namespace detail {
 

--- a/include/boost/iterator/iterator_adaptor.hpp
+++ b/include/boost/iterator/iterator_adaptor.hpp
@@ -9,6 +9,8 @@
 
 #include <boost/static_assert.hpp>
 
+#include <boost/core/use_default.hpp>
+
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/detail/enable_if.hpp>
@@ -35,11 +37,9 @@ namespace iterators {
   // Used as a default template argument internally, merely to
   // indicate "use the default", this can also be passed by users
   // explicitly in order to specify that the default should be used.
-  struct use_default;
+  using boost::use_default;
 
 } // namespace iterators
-
-using iterators::use_default;
 
 // the incompleteness of use_default causes massive problems for
 // is_convertible (naturally).  This workaround is fortunately not


### PR DESCRIPTION
boost::use_default is now defined in Core for multiple Boost libraries.