### PR TITLE
added conversion to value_type to operator_brackets_proxy

### DIFF
--- a/include/boost/iterator/iterator_facade.hpp
+++ b/include/boost/iterator/iterator_facade.hpp
@@ -368,6 +368,23 @@ namespace iterators {
             return *m_iter;
         }
 
+        // conversion operator to value_type
+        // it is needed in case reference is not convertible to value_type by a standard conversion sequence
+        // (e.g. boost::multi_array iterators)
+        template<typename T = value_type>
+        operator typename boost::iterators::enable_if<
+            mpl::not_<
+                is_same<
+                        typename remove_reference<T>::type,
+                        typename remove_reference<reference>::type
+                >
+            >
+            , value_type
+        >::type() const
+        {
+            return *m_iter;
+        }
+
         operator_brackets_proxy& operator=(value_type const& val)
         {
             *m_iter = val;


### PR DESCRIPTION
This fix is necessary after changes to microsofts stl-implementation for the latest VS 2019 preview (16.5 preview 2): sorting a boost::multi_array with std::sort doesn't work anymore. (c.f. https://github.com/microsoft/STL/pull/289)
The reason is that operator[] returns the internal class boost::iterators::detail::operator_brackets_proxy which cannot be converted to the iterators value_type as that would require two user-defined conversions.
Furthermore, also the following code never worked with boost::multi_array (although it should have according to the documentation https://www.boost.org/doc/libs/1_72_0/libs/iterator/doc/html/iterator/generic.html#iterator.generic.facade.operator)
```
#include <boost/multi_array.hpp>

void test()
{
    boost::multi_array<double, 2, std::allocator<double>> matrix;
    // ...
    auto it = matrix.begin();
    decltype(it)::value_type t = it[0];
}
```