### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/include/boost/iterator/counting_iterator.hpp
+++ b/include/boost/iterator/counting_iterator.hpp
@@ -38,7 +38,7 @@ namespace detail
 
 # else
 
-#  if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))
+#  if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x551))
       BOOST_STATIC_CONSTANT(
           bool, value = (
               boost::is_convertible<int,T>::value

--- a/include/boost/iterator/detail/config_def.hpp
+++ b/include/boost/iterator/detail/config_def.hpp
@@ -27,7 +27,7 @@
 // because the operator-> return is improperly deduced as a non-const
 // pointer.
 #if 1 || defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION)           \
-    || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x531))
+    || BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x531))
 
 // Recall that in general, compilers without partial specialization
 // can't strip constness.  Consider counting_iterator, which normally
@@ -46,7 +46,7 @@
 
 #endif
 
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x5A0))                      \
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x5A0))                      \
     || (BOOST_WORKAROUND(BOOST_INTEL_CXX_VERSION, <= 700) && defined(_MSC_VER)) \
     || BOOST_WORKAROUND(__DECCXX_VER, BOOST_TESTED_AT(60590042))                \
     || BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x590))
@@ -88,7 +88,7 @@
 #endif
 
 #if BOOST_WORKAROUND(__GNUC__, == 3) && BOOST_WORKAROUND(__GNUC_MINOR__, < 4) && !defined(__EDG_VERSION__)   \
-    || BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))
+    || BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x551))
 #  define BOOST_NO_IS_CONVERTIBLE_TEMPLATE // The following program fails to compile:
 
 #  if 0 // test code
@@ -114,7 +114,7 @@
 # define BOOST_NO_STRICT_ITERATOR_INTEROPERABILITY
 #endif 
 
-# if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+# if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
 
 // GCC-2.95 (obsolete) eagerly instantiates templated constructors and conversion
 // operators in convertibility checks, causing premature errors.

--- a/include/boost/iterator/indirect_iterator.hpp
+++ b/include/boost/iterator/indirect_iterator.hpp
@@ -111,7 +111,7 @@ namespace iterators {
   private:
       typename super_t::reference dereference() const
       {
-# if BOOST_WORKAROUND(__BORLANDC__, < 0x5A0 )
+# if BOOST_WORKAROUND(BOOST_BORLANDC, < 0x5A0 )
           return const_cast<super_t::reference>(**this->base());
 # else
           return **this->base();

--- a/include/boost/pending/iterator_tests.hpp
+++ b/include/boost/pending/iterator_tests.hpp
@@ -180,7 +180,7 @@ void forward_iterator_test(Iterator i, T v1, T v2)
   trivial_iterator_test(i, i2, v2);
 
  // borland doesn't allow non-type template parameters
-# if !defined(__BORLANDC__) || (__BORLANDC__ > 0x551)
+# if !defined(BOOST_BORLANDC) || (BOOST_BORLANDC > 0x551)
   lvalue_test<(boost::is_pointer<Iterator>::value)>::check(i);
 #endif
 }

--- a/include/boost/pointee.hpp
+++ b/include/boost/pointee.hpp
@@ -50,7 +50,7 @@ namespace detail
       BOOST_STATIC_CONSTANT(bool, is_constant = sizeof(impl::test(*impl::x)) == 1);
 
       typedef typename mpl::if_c<
-#  if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))
+#  if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x551))
           ::boost::detail::iterator_pointee<Iterator>::is_constant
 #  else
           is_constant

--- a/test/counting_iterator_test.cpp
+++ b/test/counting_iterator_test.cpp
@@ -17,7 +17,7 @@
 
 #include <boost/config.hpp>
 
-#ifdef __BORLANDC__     // Borland mis-detects our custom iterators
+#ifdef BOOST_BORLANDC     // Borland mis-detects our custom iterators
 # pragma warn -8091     // template argument ForwardIterator passed to '...' is a output iterator
 # pragma warn -8071     // Conversion may lose significant digits (due to counting_iterator<char> += n).
 #endif
@@ -40,7 +40,7 @@
 #include <climits>
 #include <iterator>
 #include <stdlib.h>
-#ifndef __BORLANDC__
+#ifndef BOOST_BORLANDC
 # include <boost/tuple/tuple.hpp>
 #endif
 #include <vector>

--- a/test/is_lvalue_iterator.cpp
+++ b/test/is_lvalue_iterator.cpp
@@ -133,7 +133,7 @@ int main()
     BOOST_STATIC_ASSERT(!boost::is_non_const_lvalue_iterator<noncopyable_iterator>::value);
 
     BOOST_STATIC_ASSERT(boost::is_non_const_lvalue_iterator<lvalue_iterator<v> >::value);
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564))
     BOOST_STATIC_ASSERT(boost::is_non_const_lvalue_iterator<lvalue_iterator<int> >::value);
 #endif
     BOOST_STATIC_ASSERT(boost::is_non_const_lvalue_iterator<lvalue_iterator<char*> >::value);

--- a/test/iterator_adaptor_cc.cpp
+++ b/test/iterator_adaptor_cc.cpp
@@ -27,7 +27,7 @@ int main()
 #if defined(__SGI_STL_PORT)                                                             \
     || !BOOST_WORKAROUND(__GNUC__, <= 2)                                                \
     && !(BOOST_WORKAROUND(__GNUC__, == 3) && BOOST_WORKAROUND(__GNUC_MINOR__, <= 1))    \
-    && !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))                          \
+    && !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x551))                          \
     && !BOOST_WORKAROUND(__LIBCOMO_VERSION__, BOOST_TESTED_AT(29))                      \
     && !BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, <= 1)
   {

--- a/test/iterator_adaptor_test.cpp
+++ b/test/iterator_adaptor_test.cpp
@@ -56,7 +56,7 @@ struct ptr_iterator
       , V*
       , V
       , boost::random_access_traversal_tag
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x551))
       , V&
 #endif
    >
@@ -67,7 +67,7 @@ private:
       , V*
       , V
       , boost::random_access_traversal_tag
-#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))
+#if BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x551))
       , V&
 #endif
     > super_t;
@@ -226,7 +226,7 @@ main()
 # endif
 #endif
 
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) // borland drops constness
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) // borland drops constness
     test = static_assert_same<Iter1::pointer, int const*>::value;
 #endif
   }
@@ -238,7 +238,7 @@ main()
 
     test = static_assert_same<Iter::value_type, int>::value;
     test = static_assert_same<Iter::reference, int const&>::value;
-#if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564)) // borland drops constness
+#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) // borland drops constness
     test = static_assert_same<Iter::pointer, int const*>::value;
 #endif
 

--- a/test/iterator_traits_test.cpp
+++ b/test/iterator_traits_test.cpp
@@ -153,7 +153,7 @@ struct maybe_pointer_test
 input_iterator_test<std::istream_iterator<int>, int, std::ptrdiff_t, int*, int&, std::input_iterator_tag>
         istream_iterator_test;
 
-#if BOOST_WORKAROUND(__BORLANDC__, <= 0x564) && !defined(__SGI_STL_PORT)
+#if BOOST_WORKAROUND(BOOST_BORLANDC, <= 0x564) && !defined(__SGI_STL_PORT)
 typedef ::std::char_traits<char>::off_type distance;
 non_pointer_test<std::ostream_iterator<int>,int,
     distance,int*,int&,std::output_iterator_tag> ostream_iterator_test;

--- a/test/reverse_iterator_test.cpp
+++ b/test/reverse_iterator_test.cpp
@@ -161,7 +161,7 @@ int main()
 #if defined(__SGI_STL_PORT)                                                             \
     || !BOOST_WORKAROUND(__GNUC__, <= 2)                                                \
     && !(BOOST_WORKAROUND(__GNUC__, == 3) && BOOST_WORKAROUND(__GNUC_MINOR__, <= 1))    \
-    && !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x551))                          \
+    && !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x551))                          \
     && !BOOST_WORKAROUND(__LIBCOMO_VERSION__, BOOST_TESTED_AT(29))                      \
     && !BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, <= 1)
 


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.