### PR TITLE
Fix deprecated copy warnings

### DIFF
--- a/include/boost/iterator/counting_iterator.hpp
+++ b/include/boost/iterator/counting_iterator.hpp
@@ -180,6 +180,10 @@ class counting_iterator
     {}
 # endif
 
+#ifndef BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+    counting_iterator& operator=(counting_iterator const&) = default;
+#endif
+
  private:
 
     typename super_t::reference dereference() const


### PR DESCRIPTION
Implicit special member functions of counting_iterator made explicit in this PR.

Along with https://github.com/boostorg/concept_check/pull/35 ut fixes the compilation and test runs with `./b2 libs/iterator/test/ cxxstd=2a,03,11,17,14 "cxxflags=-Werror=deprecated-copy" toolset=clang-13 -j4`