### PR TITLE
Use `BOOST_STATIC_ASSERT` instead of `BOOST_MPL_ASSERT`

### DIFF
--- a/include/boost/iterator/detail/facade_iterator_category.hpp
+++ b/include/boost/iterator/detail/facade_iterator_category.hpp
@@ -144,8 +144,8 @@ struct iterator_category_with_traversal
             , Traversal
           >::value);
 
-    BOOST_STATIC_ASSERT(is_iterator_category<Category>::type::value);
-    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::type::value);
+    BOOST_STATIC_ASSERT(is_iterator_category<Category>::value);
+    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::value);
     BOOST_STATIC_ASSERT(!is_iterator_traversal<Category>::value);
 #  if !BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
     BOOST_STATIC_ASSERT(is_iterator_traversal<Traversal>::value);
@@ -157,7 +157,7 @@ struct iterator_category_with_traversal
 template <class Traversal, class ValueParam, class Reference>
 struct facade_iterator_category_impl
 {
-    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::type::value);
+    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::value);
 
     typedef typename iterator_facade_default_category<
         Traversal,ValueParam,Reference

--- a/include/boost/iterator/detail/facade_iterator_category.hpp
+++ b/include/boost/iterator/detail/facade_iterator_category.hpp
@@ -14,7 +14,7 @@
 # include <boost/mpl/eval_if.hpp>
 # include <boost/mpl/identity.hpp>
 
-#include <boost/static_assert.hpp>
+# include <boost/static_assert.hpp>
 
 # include <boost/type_traits/is_same.hpp>
 # include <boost/type_traits/is_const.hpp>
@@ -113,9 +113,9 @@ struct iterator_facade_default_category
 // True iff T is convertible to an old-style iterator category.
 template <class T>
 struct is_iterator_category
-  : integral_constant<bool,
-      is_convertible<T,std::input_iterator_tag>::value ||
-      is_convertible<T,std::output_iterator_tag>::value
+  : mpl::or_<
+        is_convertible<T,std::input_iterator_tag>
+      , is_convertible<T,std::output_iterator_tag>
     >
 {
 };
@@ -144,8 +144,8 @@ struct iterator_category_with_traversal
             , Traversal
           >::value);
 
-    BOOST_STATIC_ASSERT(is_iterator_category<Category>::value);
-    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::value);
+    BOOST_STATIC_ASSERT(is_iterator_category<Category>::type::value);
+    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::type::value);
     BOOST_STATIC_ASSERT(!is_iterator_traversal<Category>::value);
 #  if !BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
     BOOST_STATIC_ASSERT(is_iterator_traversal<Traversal>::value);
@@ -157,7 +157,7 @@ struct iterator_category_with_traversal
 template <class Traversal, class ValueParam, class Reference>
 struct facade_iterator_category_impl
 {
-    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::value);
+    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::type::value);
 
     typedef typename iterator_facade_default_category<
         Traversal,ValueParam,Reference

--- a/include/boost/iterator/detail/facade_iterator_category.hpp
+++ b/include/boost/iterator/detail/facade_iterator_category.hpp
@@ -13,14 +13,13 @@
 # include <boost/mpl/if.hpp>
 # include <boost/mpl/eval_if.hpp>
 # include <boost/mpl/identity.hpp>
-# include <boost/mpl/assert.hpp>
+
+#include <boost/static_assert.hpp>
 
 # include <boost/type_traits/is_same.hpp>
 # include <boost/type_traits/is_const.hpp>
 # include <boost/type_traits/is_reference.hpp>
 # include <boost/type_traits/is_convertible.hpp>
-
-# include <boost/type_traits/is_same.hpp>
 
 # include <boost/iterator/detail/config_def.hpp> // try to keep this last
 
@@ -114,9 +113,9 @@ struct iterator_facade_default_category
 // True iff T is convertible to an old-style iterator category.
 template <class T>
 struct is_iterator_category
-  : mpl::or_<
-        is_convertible<T,std::input_iterator_tag>
-      , is_convertible<T,std::output_iterator_tag>
+  : integral_constant<bool,
+      is_convertible<T,std::input_iterator_tag>::value ||
+      is_convertible<T,std::output_iterator_tag>::value
     >
 {
 };
@@ -139,17 +138,17 @@ struct iterator_category_with_traversal
     // Make sure this isn't used to build any categories where
     // convertibility to Traversal is redundant.  Should just use the
     // Category element in that case.
-    BOOST_MPL_ASSERT_NOT((
-        is_convertible<
+    BOOST_STATIC_ASSERT(
+        !is_convertible<
               typename iterator_category_to_traversal<Category>::type
             , Traversal
-          >));
+          >::value);
 
-    BOOST_MPL_ASSERT((is_iterator_category<Category>));
-    BOOST_MPL_ASSERT_NOT((is_iterator_category<Traversal>));
-    BOOST_MPL_ASSERT_NOT((is_iterator_traversal<Category>));
+    BOOST_STATIC_ASSERT(is_iterator_category<Category>::value);
+    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::value);
+    BOOST_STATIC_ASSERT(!is_iterator_traversal<Category>::value);
 #  if !BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1310))
-    BOOST_MPL_ASSERT((is_iterator_traversal<Traversal>));
+    BOOST_STATIC_ASSERT(is_iterator_traversal<Traversal>::value);
 #  endif
 };
 
@@ -158,7 +157,7 @@ struct iterator_category_with_traversal
 template <class Traversal, class ValueParam, class Reference>
 struct facade_iterator_category_impl
 {
-    BOOST_MPL_ASSERT_NOT((is_iterator_category<Traversal>));
+    BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::value);
 
     typedef typename iterator_facade_default_category<
         Traversal,ValueParam,Reference

--- a/include/boost/iterator/detail/facade_iterator_category.hpp
+++ b/include/boost/iterator/detail/facade_iterator_category.hpp
@@ -138,11 +138,11 @@ struct iterator_category_with_traversal
     // Make sure this isn't used to build any categories where
     // convertibility to Traversal is redundant.  Should just use the
     // Category element in that case.
-    BOOST_STATIC_ASSERT(
+    BOOST_STATIC_ASSERT((
         !is_convertible<
               typename iterator_category_to_traversal<Category>::type
             , Traversal
-          >::value);
+          >::value));
 
     BOOST_STATIC_ASSERT(is_iterator_category<Category>::value);
     BOOST_STATIC_ASSERT(!is_iterator_category<Traversal>::value);

--- a/include/boost/iterator/iterator_concepts.hpp
+++ b/include/boost/iterator/iterator_concepts.hpp
@@ -144,8 +144,8 @@ namespace boost_concepts
   {
       typedef typename std::iterator_traits<Iterator>::difference_type difference_type;
 
-      BOOST_MPL_ASSERT((boost::is_integral<difference_type>));
-      BOOST_MPL_ASSERT_RELATION(std::numeric_limits<difference_type>::is_signed, ==, true);
+      BOOST_STATIC_ASSERT(boost::is_integral<difference_type>::value);
+      BOOST_STATIC_ASSERT(std::numeric_limits<difference_type>::is_signed);
 
       BOOST_CONCEPT_ASSERT((
           boost::Convertible<

--- a/test/iterator_facade.cpp
+++ b/test/iterator_facade.cpp
@@ -147,7 +147,7 @@ struct iterator_with_proxy_reference
 
 template <class T, class U>
 void same_type(U const&)
-{ BOOST_MPL_ASSERT((boost::is_same<T,U>)); }
+{ BOOST_STATIC_ASSERT(boost::is_same<T,U>::value); }
 
 template <class I, class A>
 struct abstract_iterator

--- a/test/iterator_facade.cpp
+++ b/test/iterator_facade.cpp
@@ -147,7 +147,7 @@ struct iterator_with_proxy_reference
 
 template <class T, class U>
 void same_type(U const&)
-{ BOOST_STATIC_ASSERT(boost::is_same<T,U>::value); }
+{ BOOST_STATIC_ASSERT((boost::is_same<T,U>::value)); }
 
 template <class I, class A>
 struct abstract_iterator

--- a/test/static_assert_same.hpp
+++ b/test/static_assert_same.hpp
@@ -8,7 +8,7 @@
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/is_same.hpp>
 
-#define STATIC_ASSERT_SAME( T1,T2 ) BOOST_STATIC_ASSERT(::boost::is_same< T1, T2 >::value)
+#define STATIC_ASSERT_SAME( T1,T2 ) BOOST_STATIC_ASSERT((::boost::is_same< T1, T2 >::value))
 
 template <class T1, class T2>
 struct static_assert_same

--- a/test/static_assert_same.hpp
+++ b/test/static_assert_same.hpp
@@ -5,15 +5,15 @@
 #ifndef STATIC_ASSERT_SAME_DWA2003530_HPP
 # define STATIC_ASSERT_SAME_DWA2003530_HPP
 
-#include <boost/mpl/assert.hpp>
-# include <boost/type_traits/is_same.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_same.hpp>
 
-#define STATIC_ASSERT_SAME( T1,T2 ) BOOST_MPL_ASSERT((::boost::is_same< T1, T2 >))
+#define STATIC_ASSERT_SAME( T1,T2 ) BOOST_STATIC_ASSERT(::boost::is_same< T1, T2 >::value)
 
 template <class T1, class T2>
 struct static_assert_same
 {
-    BOOST_MPL_ASSERT((::boost::is_same< T1, T2 >));
+    STATIC_ASSERT_SAME(T1, T2);
     enum { value = 1 };
 };
 


### PR DESCRIPTION
The MPL version is slower to compile and `BOOST_STATIC_ASSERT` is already used in some places. So unify that.

This also fixes `Wzero-as-null-pointer-constant` warnings, see https://github.com/boostorg/mpl/pull/75