### PR TITLE
Performance improvement:

### DIFF
--- a/include/boost/iterator/filter_iterator.hpp
+++ b/include/boost/iterator/filter_iterator.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/type_traits/is_class.hpp>
 #include <boost/static_assert.hpp>
+#include <boost/config.hpp>
 
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
 #include <utility>

--- a/include/boost/iterator/filter_iterator.hpp
+++ b/include/boost/iterator/filter_iterator.hpp
@@ -13,6 +13,13 @@
 #include <boost/type_traits/is_class.hpp>
 #include <boost/static_assert.hpp>
 
+#if __cplusplus >= 201103L
+#include <utility>
+#define STD_MOVE(x) std::move(x)
+#else
+#define STD_MOVE(x) x
+#endif
+
 namespace boost {
 namespace iterators {
 
@@ -54,13 +61,13 @@ namespace iterators {
       filter_iterator() { }
 
       filter_iterator(Predicate f, Iterator x, Iterator end_ = Iterator())
-          : super_t(std::move(x)), m_predicate(std::move(f)), m_end(std::move(end_))
+          : super_t(STD_MOVE(x)), m_predicate(STD_MOVE(f)), m_end(STD_MOVE(end_))
       {
           satisfy_predicate();
       }
 
       filter_iterator(Iterator x, Iterator end_ = Iterator())
-        : super_t(std::move(x)), m_predicate(), m_end(std::move(end_))
+        : super_t(STD_MOVE(x)), m_predicate(), m_end(STD_MOVE(end_))
       {
         // Pro8 is a little too aggressive about instantiating the
         // body of this function.
@@ -111,7 +118,7 @@ namespace iterators {
   inline filter_iterator<Predicate,Iterator>
   make_filter_iterator(Predicate f, Iterator x, Iterator end = Iterator())
   {
-      return filter_iterator<Predicate,Iterator>(std::move(f),std::move(x),std::move(end));
+      return filter_iterator<Predicate,Iterator>(STD_MOVE(f),STD_MOVE(x),STD_MOVE(end));
   }
 
   template <class Predicate, class Iterator>
@@ -123,7 +130,7 @@ namespace iterators {
       >::type x
     , Iterator end = Iterator())
   {
-      return filter_iterator<Predicate,Iterator>(std::move(x),std::move(end));
+      return filter_iterator<Predicate,Iterator>(STD_MOVE(x),STD_MOVE(end));
   }
 
 } // namespace iterators

--- a/include/boost/iterator/filter_iterator.hpp
+++ b/include/boost/iterator/filter_iterator.hpp
@@ -13,11 +13,11 @@
 #include <boost/type_traits/is_class.hpp>
 #include <boost/static_assert.hpp>
 
-#if __cplusplus >= 201103L
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
 #include <utility>
-#define STD_MOVE(x) std::move(x)
+#define BOOST_ITERATOR_DETAIL_MOVE(x) std::move(x)
 #else
-#define STD_MOVE(x) x
+#define BOOST_ITERATOR_DETAIL_MOVE(x) x
 #endif
 
 namespace boost {
@@ -61,13 +61,13 @@ namespace iterators {
       filter_iterator() { }
 
       filter_iterator(Predicate f, Iterator x, Iterator end_ = Iterator())
-          : super_t(STD_MOVE(x)), m_predicate(STD_MOVE(f)), m_end(STD_MOVE(end_))
+          : super_t(BOOST_ITERATOR_DETAIL_MOVE(x)), m_predicate(BOOST_ITERATOR_DETAIL_MOVE(f)), m_end(BOOST_ITERATOR_DETAIL_MOVE(end_))
       {
           satisfy_predicate();
       }
 
       filter_iterator(Iterator x, Iterator end_ = Iterator())
-        : super_t(STD_MOVE(x)), m_predicate(), m_end(STD_MOVE(end_))
+        : super_t(BOOST_ITERATOR_DETAIL_MOVE(x)), m_predicate(), m_end(BOOST_ITERATOR_DETAIL_MOVE(end_))
       {
         // Pro8 is a little too aggressive about instantiating the
         // body of this function.
@@ -118,7 +118,7 @@ namespace iterators {
   inline filter_iterator<Predicate,Iterator>
   make_filter_iterator(Predicate f, Iterator x, Iterator end = Iterator())
   {
-      return filter_iterator<Predicate,Iterator>(STD_MOVE(f),STD_MOVE(x),STD_MOVE(end));
+      return filter_iterator<Predicate,Iterator>(BOOST_ITERATOR_DETAIL_MOVE(f),BOOST_ITERATOR_DETAIL_MOVE(x),BOOST_ITERATOR_DETAIL_MOVE(end));
   }
 
   template <class Predicate, class Iterator>
@@ -130,7 +130,7 @@ namespace iterators {
       >::type x
     , Iterator end = Iterator())
   {
-      return filter_iterator<Predicate,Iterator>(STD_MOVE(x),STD_MOVE(end));
+      return filter_iterator<Predicate,Iterator>(BOOST_ITERATOR_DETAIL_MOVE(x),BOOST_ITERATOR_DETAIL_MOVE(end));
   }
 
 } // namespace iterators
@@ -139,5 +139,7 @@ using iterators::filter_iterator;
 using iterators::make_filter_iterator;
 
 } // namespace boost
+
+#undef BOOST_ITERATOR_DETAIL_MOVE
 
 #endif // BOOST_FILTER_ITERATOR_23022003THW_HPP

--- a/include/boost/iterator/filter_iterator.hpp
+++ b/include/boost/iterator/filter_iterator.hpp
@@ -54,13 +54,13 @@ namespace iterators {
       filter_iterator() { }
 
       filter_iterator(Predicate f, Iterator x, Iterator end_ = Iterator())
-          : super_t(x), m_predicate(f), m_end(end_)
+          : super_t(std::move(x)), m_predicate(std::move(f)), m_end(std::move(end_))
       {
           satisfy_predicate();
       }
 
       filter_iterator(Iterator x, Iterator end_ = Iterator())
-        : super_t(x), m_predicate(), m_end(end_)
+        : super_t(std::move(x)), m_predicate(), m_end(std::move(end_))
       {
         // Pro8 is a little too aggressive about instantiating the
         // body of this function.
@@ -111,7 +111,7 @@ namespace iterators {
   inline filter_iterator<Predicate,Iterator>
   make_filter_iterator(Predicate f, Iterator x, Iterator end = Iterator())
   {
-      return filter_iterator<Predicate,Iterator>(f,x,end);
+      return filter_iterator<Predicate,Iterator>(std::move(f),std::move(x),std::move(end));
   }
 
   template <class Predicate, class Iterator>
@@ -123,7 +123,7 @@ namespace iterators {
       >::type x
     , Iterator end = Iterator())
   {
-      return filter_iterator<Predicate,Iterator>(x,end);
+      return filter_iterator<Predicate,Iterator>(std::move(x),std::move(end));
   }
 
 } // namespace iterators


### PR DESCRIPTION
Add move semantics to by-value parameters (iterator and predicate), to eliminate the cost of copy-construction. Both the Predicate (Normally a std::function, or lambda), and custom iterators can have state, which can be expensive to copy. Profiler identified this as a bottleneck while using boost::adaptors::filtered.