### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/iterator
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,28 +5,31 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/concept_check//boost_concept_check
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/detail//boost_detail
+    /boost/function_types//boost_function_types
+    /boost/fusion//boost_fusion
+    /boost/mpl//boost_mpl
+    /boost/optional//boost_optional
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/static_assert//boost_static_assert
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility ;
+
 project /boost/iterator
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/concept_check//boost_concept_check
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/detail//boost_detail
-        <library>/boost/function_types//boost_function_types
-        <library>/boost/fusion//boost_fusion
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/optional//boost_optional
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
 explicit
-    [ alias boost_iterator ]
+    [ alias boost_iterator : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_iterator test ]
     ;
 
 call-if : boost-library iterator
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/iterator

--- a/build.jam
+++ b/build.jam
@@ -7,20 +7,20 @@ import project ;
 
 project /boost/iterator
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/concept_check//boost_concept_check
-        <source>/boost/config//boost_config
-        <source>/boost/conversion//boost_conversion
-        <source>/boost/core//boost_core
-        <source>/boost/detail//boost_detail
-        <source>/boost/function_types//boost_function_types
-        <source>/boost/fusion//boost_fusion
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/optional//boost_optional
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/assert//boost_assert
+        <library>/boost/concept_check//boost_concept_check
+        <library>/boost/config//boost_config
+        <library>/boost/conversion//boost_conversion
+        <library>/boost/core//boost_core
+        <library>/boost/detail//boost_detail
+        <library>/boost/function_types//boost_function_types
+        <library>/boost/fusion//boost_fusion
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/optional//boost_optional
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -10,7 +10,6 @@ project /boost/iterator
         <library>/boost/assert//boost_assert
         <library>/boost/concept_check//boost_concept_check
         <library>/boost/config//boost_config
-        <library>/boost/conversion//boost_conversion
         <library>/boost/core//boost_core
         <library>/boost/detail//boost_detail
         <library>/boost/function_types//boost_function_types

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,33 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/iterator
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/concept_check//boost_concept_check
+        <source>/boost/config//boost_config
+        <source>/boost/conversion//boost_conversion
+        <source>/boost/core//boost_core
+        <source>/boost/detail//boost_detail
+        <source>/boost/function_types//boost_function_types
+        <source>/boost/fusion//boost_fusion
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/optional//boost_optional
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_iterator ]
+    [ alias all : boost_iterator test ]
+    ;
+
+call-if : boost-library iterator
+    ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -24,9 +24,9 @@ test-suite iterator
     [ run zip_iterator_test2_fusion_vector.cpp ]
     [ run zip_iterator_test2_fusion_list.cpp ]
 #    [ run zip_iterator_test2_fusion_deque.cpp ] // See bug report for fusion https://svn.boost.org/trac/boost/ticket/11572
-    [ run zip_iterator_test_fusion.cpp : : : <source>/boost/assign//boost_assign ]
-    [ run zip_iterator_test_std_tuple.cpp : : : <source>/boost/assign//boost_assign ]
-    [ run zip_iterator_test_std_pair.cpp : : : <source>/boost/assign//boost_assign ]
+    [ run zip_iterator_test_fusion.cpp : : : <library>/boost/assign//boost_assign ]
+    [ run zip_iterator_test_std_tuple.cpp : : : <library>/boost/assign//boost_assign ]
+    [ run zip_iterator_test_std_pair.cpp : : : <library>/boost/assign//boost_assign ]
 
     [ run is_iterator.cpp ]
 
@@ -63,10 +63,10 @@ test-suite iterator
     [ compile-fail minimum_category_compile_fail.cpp ]
 
     [ run next_prior_test.cpp ]
-    [ run advance_test.cpp : : : <source>/boost/container//boost_container ]
-    [ run distance_test.cpp : : : <source>/boost/container//boost_container ]
-    [ compile adl_test.cpp : <source>/boost/array//boost_array ]
-    [ compile range_distance_compat_test.cpp : <source>/boost/range//boost_range ]
+    [ run advance_test.cpp : : : <library>/boost/container//boost_container ]
+    [ run distance_test.cpp : : : <library>/boost/container//boost_container ]
+    [ compile adl_test.cpp : <library>/boost/array//boost_array ]
+    [ compile range_distance_compat_test.cpp : <library>/boost/range//boost_range ]
 
     [ run shared_iterator_test.cpp ]
 ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -22,9 +22,9 @@ test-suite iterator
     [ run zip_iterator_test2_fusion_vector.cpp ]
     [ run zip_iterator_test2_fusion_list.cpp ]
 #    [ run zip_iterator_test2_fusion_deque.cpp ] // See bug report for fusion https://svn.boost.org/trac/boost/ticket/11572
-    [ run zip_iterator_test_fusion.cpp ]
-    [ run zip_iterator_test_std_tuple.cpp ]
-    [ run zip_iterator_test_std_pair.cpp ]
+    [ run zip_iterator_test_fusion.cpp : : : <source>/boost/assign//boost_assign ]
+    [ run zip_iterator_test_std_tuple.cpp : : : <source>/boost/assign//boost_assign ]
+    [ run zip_iterator_test_std_pair.cpp : : : <source>/boost/assign//boost_assign ]
 
     [ run is_iterator.cpp ]
 
@@ -61,10 +61,10 @@ test-suite iterator
     [ compile-fail minimum_category_compile_fail.cpp ]
 
     [ run next_prior_test.cpp ]
-    [ run advance_test.cpp ]
-    [ run distance_test.cpp ]
-    [ compile adl_test.cpp ]
-    [ compile range_distance_compat_test.cpp ]
+    [ run advance_test.cpp : : : <source>/boost/container//boost_container ]
+    [ run distance_test.cpp : : : <source>/boost/container//boost_container ]
+    [ compile adl_test.cpp : <source>/boost/array//boost_array ]
+    [ compile range_distance_compat_test.cpp : <source>/boost/range//boost_range ]
 
     [ run shared_iterator_test.cpp ]
 ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -2,6 +2,8 @@
 # Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+import testing ;
+
 test-suite iterator
   :
     # These first two tests will run last, and are expected to fail

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -4,6 +4,8 @@
 
 import testing ;
 
+project : requirements <library>/boost/iterator//boost_iterator ;
+
 test-suite iterator
   :
     # These first two tests will run last, and are expected to fail


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.