### PR TITLE
Make transform iterator save underlying iterator category.

### DIFF
--- a/include/boost/iterator/counting_iterator.hpp
+++ b/include/boost/iterator/counting_iterator.hpp
@@ -171,6 +171,7 @@ private:
 
 public:
     using reference = typename super_t::reference;
+    using value_type = typename super_t::value_type;
     using difference_type = typename super_t::difference_type;
 
     counting_iterator() = default;
@@ -181,6 +182,11 @@ public:
     counting_iterator(Incrementable x) :
         super_t(x)
     {
+    }
+
+    value_type operator[](difference_type n) const {
+        auto ret_iter = *this;
+        return *(ret_iter + n);
     }
 
 private:

--- a/include/boost/iterator/iterator_facade.hpp
+++ b/include/boost/iterator/iterator_facade.hpp
@@ -368,41 +368,6 @@ private:
     Iterator m_iter;
 };
 
-// A metafunction that determines whether operator[] must return a
-// proxy, or whether it can simply return a copy of the value_type.
-template< typename ValueType, typename Reference >
-struct use_operator_brackets_proxy :
-    public detail::negation<
-        detail::conjunction<
-            std::is_copy_constructible< ValueType >,
-            std::is_trivial< ValueType >,
-            iterator_writability_disabled< ValueType, Reference >
-        >
-    >
-{};
-
-template< typename Iterator, typename Value, typename Reference >
-struct operator_brackets_result
-{
-    using type = typename std::conditional<
-        use_operator_brackets_proxy<Value, Reference>::value,
-        operator_brackets_proxy<Iterator>,
-        Value
-    >::type;
-};
-
-template< typename Iterator >
-inline operator_brackets_proxy<Iterator> make_operator_brackets_result(Iterator const& iter, std::true_type)
-{
-    return operator_brackets_proxy< Iterator >(iter);
-}
-
-template< typename Iterator >
-inline typename Iterator::value_type make_operator_brackets_result(Iterator const& iter, std::false_type)
-{
-    return *iter;
-}
-
 // A binary metafunction class that always returns bool.
 template< typename Iterator1, typename Iterator2 >
 using always_bool_t = bool;
@@ -679,13 +644,12 @@ public:
     using difference_type = typename base_type::difference_type;
 
 public:
-    typename boost::iterators::detail::operator_brackets_result< Derived, Value, reference >::type
+    Reference
     operator[](difference_type n) const
     {
-        return boost::iterators::detail::make_operator_brackets_result< Derived >(
-            this->derived() + n,
-            std::integral_constant< bool, boost::iterators::detail::use_operator_brackets_proxy< Value, Reference >::value >{}
-        );
+        Derived derived = this->derived();
+        iterator_core_access::advance(derived, n);
+        return iterator_core_access::dereference(derived);
     }
 
     Derived& operator+=(difference_type n)

--- a/include/boost/iterator/iterator_facade.hpp
+++ b/include/boost/iterator/iterator_facade.hpp
@@ -641,6 +641,7 @@ private:
 
 public:
     using reference = typename base_type::reference;
+    using value_type = typename base_type::value_type;
     using difference_type = typename base_type::difference_type;
 
 public:

--- a/include/boost/iterator/transform_iterator.hpp
+++ b/include/boost/iterator/transform_iterator.hpp
@@ -35,6 +35,34 @@ struct transform_iterator_default_reference
     using type = decltype(std::declval< UnaryFunc const& >()(*std::declval< Iterator >()));
 };
 
+template < typename Iterator, class Enable = void >
+struct transform_iterator_category_base {
+};
+
+template <class IterCategory>
+struct transform_iterator_category_base_impl {
+    using type = IterCategory;
+};
+
+template <>
+struct transform_iterator_category_base_impl<std::output_iterator_tag> {
+    using type = std::input_iterator_tag;
+};
+
+template<class T, class R = void>
+struct enable_if_type { using type = R; };
+
+template < typename Iterator >
+struct transform_iterator_category_base<
+    Iterator,
+    typename enable_if_type<typename std::iterator_traits<Iterator>::iterator_category>::type
+>
+{
+    using type = typename transform_iterator_category_base_impl<
+                    typename std::iterator_traits<Iterator>::iterator_category
+                 >::type;
+};
+
 // Compute the iterator_adaptor instantiation to be used for transform_iterator
 template< typename UnaryFunc, typename Iterator, typename Reference, typename Value >
 struct transform_iterator_base
@@ -81,6 +109,8 @@ private:
     using functor_base = boost::empty_value< UnaryFunc >;
 
 public:
+
+    using iterator_category = typename detail::transform_iterator_category_base< Iterator >::type;
 
     transform_iterator() = default;
 

--- a/include/boost/iterator/transform_iterator.hpp
+++ b/include/boost/iterator/transform_iterator.hpp
@@ -32,7 +32,7 @@ namespace detail {
 template< typename UnaryFunc, typename Iterator >
 struct transform_iterator_default_reference
 {
-    using type = decltype(std::declval< UnaryFunc const& >()(std::declval< typename std::iterator_traits< Iterator >::reference >()));
+    using type = decltype(std::declval< UnaryFunc const& >()(*std::declval< Iterator >()));
 };
 
 // Compute the iterator_adaptor instantiation to be used for transform_iterator
@@ -81,6 +81,7 @@ private:
     using functor_base = boost::empty_value< UnaryFunc >;
 
 public:
+
     transform_iterator() = default;
 
     transform_iterator(Iterator const& x, UnaryFunc f) :


### PR DESCRIPTION
- operator[] in iterator facade now returns a reference, because its return type must be the same as dereference type for random_access_iterator concept.
- add tests for categories checks.
- change trait to determine transform_iterator reference type.