### PR TITLE
Constrain distance function using is_iterator type trait

### DIFF
--- a/include/boost/iterator/advance.hpp
+++ b/include/boost/iterator/advance.hpp
@@ -60,7 +60,7 @@ namespace advance_adl_barrier {
 
 template< typename InputIterator, typename Distance >
 inline BOOST_CXX14_CONSTEXPR
-typename std::enable_if< boost::is_iterator< SinglePassIterator >::value, void > >::type
+typename std::enable_if< boost::is_iterator< InputIterator >::value, void > >::type
 advance(InputIterator& it, Distance n)
 {
     detail::advance_impl(it, n, typename iterator_traversal< InputIterator >::type());

--- a/include/boost/iterator/advance.hpp
+++ b/include/boost/iterator/advance.hpp
@@ -60,7 +60,7 @@ namespace advance_adl_barrier {
 
 template< typename InputIterator, typename Distance >
 inline BOOST_CXX14_CONSTEXPR
-typename std::enable_if< boost::is_iterator< InputIterator >::value, void > >::type
+typename std::enable_if< boost::is_iterator< InputIterator >::value, void >::type
 advance(InputIterator& it, Distance n)
 {
     detail::advance_impl(it, n, typename iterator_traversal< InputIterator >::type());

--- a/include/boost/iterator/advance.hpp
+++ b/include/boost/iterator/advance.hpp
@@ -8,7 +8,10 @@
 #define BOOST_ITERATOR_ADVANCE_HPP
 
 #include <boost/config.hpp>
+#include <boost/iterator/is_iterator.hpp>
 #include <boost/iterator/iterator_categories.hpp>
+
+#include <type_traits>
 
 namespace boost {
 namespace iterators {
@@ -56,7 +59,9 @@ inline BOOST_CXX14_CONSTEXPR void advance_impl(RandomAccessIterator& it, Distanc
 namespace advance_adl_barrier {
 
 template< typename InputIterator, typename Distance >
-inline BOOST_CXX14_CONSTEXPR void advance(InputIterator& it, Distance n)
+inline BOOST_CXX14_CONSTEXPR
+typename std::enable_if< boost::is_iterator< SinglePassIterator >::value, void > >::type
+advance(InputIterator& it, Distance n)
 {
     detail::advance_impl(it, n, typename iterator_traversal< InputIterator >::type());
 }

--- a/include/boost/iterator/distance.hpp
+++ b/include/boost/iterator/distance.hpp
@@ -43,8 +43,8 @@ namespace distance_adl_barrier {
 
 template< typename SinglePassIterator >
 inline BOOST_CXX14_CONSTEXPR
-boost::enable_if< boost::is_iterator< SinglePassIterator >,
-                    typename iterator_difference< SinglePassIterator >::type >::type
+typename boost::enable_if< boost::is_iterator< SinglePassIterator >,
+                           typename iterator_difference< SinglePassIterator >::type >::type
 distance(SinglePassIterator first, SinglePassIterator last)
 {
     return detail::distance_impl(first, last, typename iterator_traversal< SinglePassIterator >::type());

--- a/include/boost/iterator/distance.hpp
+++ b/include/boost/iterator/distance.hpp
@@ -43,8 +43,10 @@ namespace distance_adl_barrier {
 
 template< typename SinglePassIterator >
 inline BOOST_CXX14_CONSTEXPR
-typename boost::enable_if< boost::is_iterator< SinglePassIterator >,
-                           typename iterator_difference< SinglePassIterator >::type >::type
+typename std::enable_if<
+    boost::is_iterator< SinglePassIterator >::value,
+    iterator_difference< SinglePassIterator >
+>::type::type
 distance(SinglePassIterator first, SinglePassIterator last)
 {
     return detail::distance_impl(first, last, typename iterator_traversal< SinglePassIterator >::type());

--- a/include/boost/iterator/distance.hpp
+++ b/include/boost/iterator/distance.hpp
@@ -8,6 +8,7 @@
 #define BOOST_ITERATOR_DISTANCE_HPP
 
 #include <boost/config.hpp>
+#include <boost/iterator/is_iterator.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/iterator/iterator_traits.hpp>
 
@@ -40,7 +41,9 @@ distance_impl(RandomAccessIterator first, RandomAccessIterator last, random_acce
 namespace distance_adl_barrier {
 
 template< typename SinglePassIterator >
-inline BOOST_CXX14_CONSTEXPR typename iterator_difference< SinglePassIterator >::type
+inline BOOST_CXX14_CONSTEXPR
+boost::enable_if_c< boost::is_iterator< SinglePassIterator >::value,
+                    typename iterator_difference< SinglePassIterator >::type >
 distance(SinglePassIterator first, SinglePassIterator last)
 {
     return detail::distance_impl(first, last, typename iterator_traversal< SinglePassIterator >::type());

--- a/include/boost/iterator/distance.hpp
+++ b/include/boost/iterator/distance.hpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2017 Michel Morin.
+// Copyright (C) 2026 Jeremy W. Murphy
 //
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
@@ -8,10 +9,11 @@
 #define BOOST_ITERATOR_DISTANCE_HPP
 
 #include <boost/config.hpp>
-#include <boost/core/enable_if.hpp>
 #include <boost/iterator/is_iterator.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/iterator/iterator_traits.hpp>
+
+#include <type_traits>
 
 namespace boost {
 namespace iterators {

--- a/include/boost/iterator/distance.hpp
+++ b/include/boost/iterator/distance.hpp
@@ -8,6 +8,7 @@
 #define BOOST_ITERATOR_DISTANCE_HPP
 
 #include <boost/config.hpp>
+#include <boost/core/enable_if.hpp>
 #include <boost/iterator/is_iterator.hpp>
 #include <boost/iterator/iterator_categories.hpp>
 #include <boost/iterator/iterator_traits.hpp>

--- a/include/boost/iterator/distance.hpp
+++ b/include/boost/iterator/distance.hpp
@@ -43,8 +43,8 @@ namespace distance_adl_barrier {
 
 template< typename SinglePassIterator >
 inline BOOST_CXX14_CONSTEXPR
-boost::enable_if_c< boost::is_iterator< SinglePassIterator >::value,
-                    typename iterator_difference< SinglePassIterator >::type >
+boost::enable_if< boost::is_iterator< SinglePassIterator >,
+                    typename iterator_difference< SinglePassIterator >::type >::type
 distance(SinglePassIterator first, SinglePassIterator last)
 {
     return detail::distance_impl(first, last, typename iterator_traversal< SinglePassIterator >::type());

--- a/test/advance_test.cpp
+++ b/test/advance_test.cpp
@@ -4,6 +4,8 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <cstddef>
+#include <functional>
 #include <vector>
 #include <list>
 #include <boost/container/slist.hpp>
@@ -18,6 +20,12 @@ void test_advance(Iterator it_from, Iterator it_to, int n)
 {
     boost::advance(it_from,  n);
     BOOST_TEST(it_from == it_to);
+}
+
+// Overload for integers
+void advance(int &x, int n)
+{
+    x += n;
 }
 
 int main()
@@ -87,5 +95,10 @@ int main()
         );
     }
 
+    {
+        int x = 0;
+        test_advance(std::ref(x), 3, 3);
+    }
+    
     return boost::report_errors();
 }

--- a/test/advance_test.cpp
+++ b/test/advance_test.cpp
@@ -26,7 +26,7 @@ struct Foo
     int x = 0;
 
     friend
-    void advance(Foo &value, int n)
+    void advance(Foo &value, long n)
     {
         value.x += 10 * n;
     }

--- a/test/advance_test.cpp
+++ b/test/advance_test.cpp
@@ -25,6 +25,8 @@ struct Foo
 {
     int x = 0;
 
+    // Don't use type "int" for "n", otherwise it matches literal int exactly
+    // and doesn't demonstrate the effect of enable_if.
     friend
     void advance(Foo &value, long n)
     {

--- a/test/advance_test.cpp
+++ b/test/advance_test.cpp
@@ -4,8 +4,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <cstddef>
-#include <functional>
 #include <vector>
 #include <list>
 #include <boost/container/slist.hpp>
@@ -22,11 +20,17 @@ void test_advance(Iterator it_from, Iterator it_to, int n)
     BOOST_TEST(it_from == it_to);
 }
 
-// Overload for integers
-void advance(int &x, int n)
+// Definitely not an iterator
+struct Foo
 {
-    x += n;
-}
+    int x = 0;
+
+    friend constexpr
+    void advance(Foo &value, int n)
+    {
+        value.x += 10 * n;
+    }
+};
 
 int main()
 {
@@ -96,8 +100,10 @@ int main()
     }
 
     {
-        int x = 0;
-        test_advance(std::ref(x), 3, 3);
+        using boost::advance;
+        Foo bar;
+        advance(bar, 3);
+        BOOST_TEST(bar.x == 30);
     }
     
     return boost::report_errors();

--- a/test/advance_test.cpp
+++ b/test/advance_test.cpp
@@ -25,7 +25,7 @@ struct Foo
 {
     int x = 0;
 
-    friend constexpr
+    friend
     void advance(Foo &value, int n)
     {
         value.x += 10 * n;

--- a/test/distance_test.cpp
+++ b/test/distance_test.cpp
@@ -4,6 +4,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#include <cstddef>
 #include <vector>
 #include <list>
 #include <boost/container/slist.hpp>
@@ -84,10 +85,10 @@ int main()
         // Definitely not an iterator.
         struct Foo
         {
-            friend
-            std::ptr_diff distance(Foo const &, Foo const &) { return -1; }
+            constexpr friend
+            std::ptrdiff_t distance(Foo const &, Foo const &) { return -1; }
         };
-        // Make it visible.
+        // Make boost::distance visible since we're not actually in the boost namespace here.
         using boost::distance;
         auto result = distance(Foo{}, Foo{});
         BOOST_TEST(result == -1);

--- a/test/distance_test.cpp
+++ b/test/distance_test.cpp
@@ -20,6 +20,13 @@ void test_distance(Iterator it_from, Iterator it_to, int n)
     BOOST_TEST(boost::distance(it_from, it_to) == n);
 }
 
+// Definitely not an iterator.
+struct Foo
+{
+    constexpr friend
+    std::ptrdiff_t distance(Foo const &, Foo const &) { return -1; }
+};
+
 int main()
 {
     int array[3] = {1, 2, 3};
@@ -82,12 +89,6 @@ int main()
     }
 
     {
-        // Definitely not an iterator.
-        struct Foo
-        {
-            constexpr friend
-            std::ptrdiff_t distance(Foo const &, Foo const &) { return -1; }
-        };
         // Make boost::distance visible since we're not actually in the boost namespace here.
         using boost::distance;
         auto result = distance(Foo{}, Foo{});

--- a/test/distance_test.cpp
+++ b/test/distance_test.cpp
@@ -80,5 +80,17 @@ int main()
         );
     }
 
+    {
+        // Definitely not an iterator.
+        struct Foo
+        {
+            friend
+            std::ptr_diff distance(Foo const &, Foo const &) { return -1; }
+        };
+        // Make it visible.
+        using boost::distance;
+        auto result = distance(Foo{}, Foo{});
+        BOOST_TEST(result == -1);
+    }
     return boost::report_errors();
 }


### PR DESCRIPTION
`distance` will match anything, which gets annoying when your geometry algorithm for distance is... `distance`.
(Same goes for `advance`.)

Use `enable_if` to constrain both functions to types that satisfy the library's definition of an iterator with `boost::is_iterator`.